### PR TITLE
Update gitignore to include compiled assembler and output bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ dkms.conf
 *.sw*
 tools/report
 
+# Compiler assembler & output bins
+asm
+/*.bin


### PR DESCRIPTION
Referring to the lab slides,  
> <img width="1149" alt="image" src="https://github.com/MingjunLi99/ceng3420/assets/40143583/265cfaf9-18b5-41ce-99bf-5bce0f4ef0a9">

The `make` command will generate an `./asm` file, and the compiled program is supposed to generate various bin files, which both should not be pushed to the remote.

**Edit:** Should this PR be pushed to the upstream at [baichen318/ceng3420](https://github.com/baichen318/ceng3420) instead?