### PR TITLE
Fix handle_label_or_imm() tip

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -288,7 +288,7 @@ int inst_to_binary(
         /*
          * Lab2-1 assignment
          * tip: you may need the function `handle_label_or_imm`
-         * e.g., handle_label_or_imm(arg2, label_table, cmd_no, line_no)
+         * e.g., handle_label_or_imm(line_no, arg2, label_table, number_of_labels)
          */
         warn("Lab2-1 assignment: JAL instruction\n");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
The tip for handle_label_or_imm() is outdated. It should be `handle_label_or_imm(line_no, arg2, label_table, number_of_labels)` instead.

Edit: I haven't checked the other branches for changes. 